### PR TITLE
Refactor dispatcher initialization

### DIFF
--- a/mybot/handlers/__init__.py
+++ b/mybot/handlers/__init__.py
@@ -1,9 +1,11 @@
-# ==== bot/__init__.py ====
-# Ботын үндсэн Dispatcher, Bot, Storage-уудыг тохируулах
-from aiogram import Bot, Dispatcher
-from aiogram.contrib.fsm_storage.memory import MemoryStorage
-from config import API_TOKEN
+"""Handlers package initialization.
 
-bot = Bot(token=API_TOKEN)
-storage = MemoryStorage()
-dp = Dispatcher(bot, storage=storage)
+This module only exposes the ``bot`` and ``dp`` instances from the
+top-level :mod:`mybot` package to keep backward compatibility.  The
+actual creation of the bot, dispatcher and storage now lives in
+``mybot.__init__`` so that there is a single source of truth.
+"""
+
+from mybot import bot, dp
+
+__all__ = ["bot", "dp"]

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,9 +1,10 @@
-# ==== bot/__init__.py ====
-# Ботын үндсэн Dispatcher, Bot, Storage-уудыг тохируулах
-from aiogram import Bot, Dispatcher
-from aiogram.contrib.fsm_storage.memory import MemoryStorage
-from config import API_TOKEN
+"""Service layer package initialization.
 
-bot = Bot(token=API_TOKEN)
-storage = MemoryStorage()
-dp = Dispatcher(bot, storage=storage)
+Only re-exports the ``bot`` and ``dp`` objects from :mod:`mybot`.  The
+instances themselves are created in ``mybot.__init__`` to avoid
+duplication.
+"""
+
+from mybot import bot, dp
+
+__all__ = ["bot", "dp"]

--- a/sheets/__init__.py
+++ b/sheets/__init__.py
@@ -1,9 +1,10 @@
-# ==== bot/__init__.py ====
-# Ботын үндсэн Dispatcher, Bot, Storage-уудыг тохируулах
-from aiogram import Bot, Dispatcher
-from aiogram.contrib.fsm_storage.memory import MemoryStorage
-from config import API_TOKEN
+"""Sheets package initialization.
 
-bot = Bot(token=API_TOKEN)
-storage = MemoryStorage()
-dp = Dispatcher(bot, storage=storage)
+Exports ``bot`` and ``dp`` from :mod:`mybot` so that any legacy code
+importing them from here continues to work.  Creation of these objects
+is centralized in ``mybot.__init__``.
+"""
+
+from mybot import bot, dp
+
+__all__ = ["bot", "dp"]


### PR DESCRIPTION
## Summary
- centralize bot, dispatcher and storage creation in `mybot.__init__`
- expose `bot` and `dp` from `handlers`, `services` and `sheets`

## Testing
- `find . -name "*.py" -print -exec python -m py_compile {} +`

------
https://chatgpt.com/codex/tasks/task_e_6841156cd0ac8322a71e6b49d993b85b