### PR TITLE
Fix location handler overlap

### DIFF
--- a/mybot/handlers/user.py
+++ b/mybot/handlers/user.py
@@ -93,7 +93,7 @@ async def checkin_handler(message: types.Message):
     )
 
   # Байршил хүлээж авах үед checkin хийх
-@dp.message_handler(content_types=['location'])
+@dp.message_handler(content_types=['location'], state=None)
 async def location_handler(message: types.Message):
     loc = message.location
     # Заавал live_location шалгана


### PR DESCRIPTION
## Summary
- prevent generic location handler from activating during FSM flows

## Testing
- `find . -name "*.py" -print0 | xargs -0 python -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_68410b360704832284ef5d9abad8009f