### PR TITLE
Remove path hack from user handler

### DIFF
--- a/mybot/handlers/user.py
+++ b/mybot/handlers/user.py
@@ -1,8 +1,5 @@
 # ==== mybot/handlers/user.py ====
 # Хэрэглэгчийн command, FSM registration, checkin/checkout болон зураг хадгалах
-import sys
-import os
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
 
 from aiogram import types
 from aiogram.dispatcher import FSMContext


### PR DESCRIPTION
## Summary
- clean up `mybot/handlers/user.py` imports
- rely on package imports without altering `sys.path`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841158af064832295c5907d297bbc60