### PR TITLE
Add logging configuration and instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The bot expects the following variables to be available in the environment:
 - `SHEET_URL_ATTENDANCE` – URL of the Google Sheet where attendance records are stored.
 - `SHEET_URL_LOCATION` – URL of the Google Sheet that lists office locations.
 - `ADMIN_IDS` – Comma-separated list of Telegram user IDs with admin rights.
+- `LOG_LEVEL` – Optional logging level (e.g. `DEBUG`, `INFO`). Defaults to `INFO`.
 
 In addition, Google service account credentials must be provided either via `GOOGLE_CREDS_JSON` (JSON string) or by pointing `CREDS_FILE` to a credentials file. `WORKSHEET_NAME` can be set to choose a different worksheet name for location data (defaults to `offices`).
 

--- a/main.py
+++ b/main.py
@@ -4,7 +4,12 @@ from aiogram import executor
 from mybot import dp
 import mybot.handlers.user
 import mybot.handlers.menu
+from utils.logging_config import setup_logging
+import logging
 
 
 if __name__ == "__main__":
+    setup_logging()
+    logger = logging.getLogger(__name__)
+    logger.info("Starting bot polling")
     executor.start_polling(dp, skip_updates=True)

--- a/mybot/handlers/admin.py
+++ b/mybot/handlers/admin.py
@@ -2,6 +2,7 @@
 
 import os
 from aiogram import Dispatcher, types
+import logging
 try:  # pragma: no cover - fallback for test stubs
     from aiogram.types import ReplyKeyboardRemove
 except Exception:  # pragma: no cover - fallback for tests without this class
@@ -11,6 +12,7 @@ except Exception:  # pragma: no cover - fallback for tests without this class
 
 # Parsed list of admin Telegram IDs will be loaded from the environment
 ADMIN_IDS: list[int] = []
+logger = logging.getLogger(__name__)
 
 
 def _get_admin_ids() -> set[int]:

--- a/mybot/handlers/menu.py
+++ b/mybot/handlers/menu.py
@@ -3,6 +3,9 @@ from aiogram.dispatcher.filters import Command
 from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
 from aiogram.dispatcher import FSMContext
 from mybot import dp
+import logging
+
+logger = logging.getLogger(__name__)
 
 # --- Keyboard ---
 menu_keyboard = ReplyKeyboardMarkup(
@@ -18,6 +21,7 @@ menu_keyboard = ReplyKeyboardMarkup(
 @dp.message_handler(commands=['menu', 'start'], state='*')
 async def send_menu(message: types.Message, state: FSMContext):
     await state.finish()
+    logger.info("Displaying menu for user %s", message.from_user.id)
     await message.answer(
         "Доорх цэснээс сонгоно уу:",
         reply_markup=menu_keyboard

--- a/services/registration.py
+++ b/services/registration.py
@@ -3,6 +3,9 @@ from sheets.employees import find_employee_register_row, register_employee_teleg
 from sheets.attendance import is_register_number_registered
 from sheets.base import get_sheet
 from config import SHEET_URL_EMPLOYEES, SHEET_URL_ATTENDANCE
+import logging
+
+logger = logging.getLogger(__name__)
 
 def is_telegram_id_registered(telegram_user_id):
     # Telegram ID өмнө нь бүртгэгдсэн эсэхийг шалгах

--- a/sheets/attendance.py
+++ b/sheets/attendance.py
@@ -3,6 +3,9 @@
 from sheets.base import get_sheet
 from config import SHEET_URL_ATTENDANCE
 from datetime import datetime
+import logging
+
+logger = logging.getLogger(__name__)
 
 def is_register_number_registered(register_number):
     # Attendance-д регистр бүртгэгдсэн эсэх
@@ -35,6 +38,7 @@ def add_register(telegram_user_id, username, register_number, last_name, first_n
         '',                   # S
     ]
     sheet.append_row(row)
+    logger.info("Registered user %s (%s)", telegram_user_id, register_number)
 
 def add_checkin(
     telegram_user_id, 
@@ -67,6 +71,7 @@ def add_checkin(
         office_name
     ]
     sheet.append_row(row)
+    logger.info("Checkin recorded for %s at %s", telegram_user_id, office_name)
 
 def add_checkout(
     telegram_user_id,
@@ -100,3 +105,4 @@ def add_checkout(
         office_name
     ]
     sheet.append_row(row)
+    logger.info("Checkout recorded for %s at %s", telegram_user_id, office_name)

--- a/sheets/base.py
+++ b/sheets/base.py
@@ -5,6 +5,9 @@ from utils.gsheet_cache import (
     get_sheet as cached_get_sheet,
     get_worksheet,
 )
+import logging
+
+logger = logging.getLogger(__name__)
 
 def get_sheet(url):
     return cached_get_sheet(url)
@@ -25,5 +28,5 @@ def get_offices_from_sheet(sheet_url, creds_file='credentials.json', worksheet_n
                 'lon': float(row['lon'])
             })
         except Exception as e:
-            print(f"Алдаатай мөр алгасав: {row} ({e})")
+            logger.warning("Алдаатай мөр алгасав: %s (%s)", row, e)
     return offices

--- a/sheets/employees.py
+++ b/sheets/employees.py
@@ -2,6 +2,9 @@
 # Employees sheet-тэй холбоотой бүх функцүүд (хайлт, бүртгэл)
 from sheets.base import get_sheet
 from config import SHEET_URL_EMPLOYEES
+import logging
+
+logger = logging.getLogger(__name__)
 
 def find_employee_register_row(register_number):
     # Регистрийн дугаараар ажилтны мэдээллийг хайх
@@ -9,6 +12,7 @@ def find_employee_register_row(register_number):
     records = sheet.get_all_records()
     for idx, row in enumerate(records):
         if str(row['register_number']) == str(register_number):
+            logger.debug("Found employee row for %s", register_number)
             return idx + 2, row
     return None, None
 
@@ -24,5 +28,8 @@ def register_employee_telegram_id(register_number, telegram_user_id):
     row_number, row = find_employee_register_row(register_number)
     if row_number:
         sheet.update_cell(row_number, 4, str(telegram_user_id))
+        logger.info(
+            "Linked telegram id %s to register %s", telegram_user_id, register_number
+        )
         return True
     return False

--- a/utils/logging_config.py
+++ b/utils/logging_config.py
@@ -1,0 +1,12 @@
+import logging
+import os
+
+
+def setup_logging() -> None:
+    """Configure basic logging using level from ``LOG_LEVEL`` env variable."""
+    level_name = os.environ.get("LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )


### PR DESCRIPTION
## Summary
- add `utils/logging_config.setup_logging` to configure log level from `LOG_LEVEL`
- initialise logging in `main.py`
- use module loggers in handlers and sheets modules
- log key register/checkin/checkout actions
- document `LOG_LEVEL` environment variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841471a7cc08322aec3196ecc04d7cf