### PR TITLE
Add admin handlers to bot startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from aiogram import executor
 from mybot import dp
 import mybot.handlers.user
 import mybot.handlers.menu
+from mybot.handlers.admin import register_admin_handlers
 from utils.logging_config import setup_logging
 import logging
 
@@ -12,4 +13,5 @@ if __name__ == "__main__":
     setup_logging()
     logger = logging.getLogger(__name__)
     logger.info("Starting bot polling")
+    register_admin_handlers(dp)
     executor.start_polling(dp, skip_updates=True)


### PR DESCRIPTION
## Summary
- register admin handlers when starting the bot

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684563a0ff14832286e470d18941e146